### PR TITLE
fix a bug that would cause image-text mismatch of VQA evaluation

### DIFF
--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -289,7 +289,7 @@ class HFLM(TemplateLM):
             if image_src_split:
                 self.image_src_split = image_src_split
             else:
-                self.image_src_split = "test"
+                self.image_src_split = "test" if image_src == "facebook/winoground" else "validation"
             self.image_src = load_dataset(image_src)[self.image_src_split]
 
         self.truncation = truncation


### PR DESCRIPTION
During evaluation, VQA uses the `validation` split and Winoground uses the `test` split, so the default `image_src_split` should depend on `image_src`. Otherwise, unmatched image-text pairs would be passed to the VLM and get meaningless VQA score.